### PR TITLE
average.jsの平均化処理を修正

### DIFF
--- a/average.js
+++ b/average.js
@@ -23,8 +23,10 @@ module.exports = function main(returnField) {
           }
         }
         const keys = Object.keys(avarages);
+        let key;
         for (let i = 0; i < keys.length; i += 1) {
-          avarages[i] = parseInt(avarages[i] / results.length, 10);
+          key = keys[i];
+          avarages[key] = parseInt(avarages[key] / results.length, 10);
         }
         const returnObj = results;
         returnObj.average = avarages;


### PR DESCRIPTION
合計を個数で割るときに、averages[i]であったところをaverages[kys[i]]に修正